### PR TITLE
fix: update loading spinner color from blue to red in Dashboard compo…

### DIFF
--- a/src/pages/client/dashboard/Dashboard.jsx
+++ b/src/pages/client/dashboard/Dashboard.jsx
@@ -30,7 +30,7 @@ const Dashboard = () => {
     return (
       <ClientLayout>
         <div className="flex items-center justify-center h-full">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-red-600"></div>
         </div>
       </ClientLayout>
     );


### PR DESCRIPTION
This pull request makes a minor visual update to the loading spinner on the dashboard page. The spinner's color has been changed from blue to red to better match the desired UI theme.

* Changed the border color of the loading spinner from blue (`border-blue-600`) to red (`border-red-600`) in `Dashboard.jsx`.…nent